### PR TITLE
NoUnsafePorts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
     "cSpell.words": [
         "Dict",
         "foldl",
+        "Fuzzer",
+        "tuple",
+        "Tupled",
         "tuples"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,12 @@
 {
     "cSpell.enabled": true,
     "cSpell.words": [
+        "concat",
         "Dict",
         "foldl",
         "Fuzzer",
         "tuple",
         "Tupled",
-        "tuples"
+        "tuples",
     ]
 }

--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ Provides [`elm-review`](https://package.elm-lang.org/packages/jfmengels/elm-revi
 ## Provided rules
 
 - [`NoDuplicatePorts`](https://package.elm-lang.org/packages/sparksp/elm-review-ports/latest/NoDuplicatePorts) - Ensure that port names are unique across your project.
-- [`NoUnusedPorts`](https://package.elm-lang.org/packages/sparksp/elm-review-ports/latest/NoDuplicatePorts) - Ensure that all defined ports have been used.
+- [`NoUnsafePorts`](https://package.elm-lang.org/packages/sparksp/elm-review-ports/latest/NoUnsafePorts) - Forbid unsafe types in ports.
+- [`NoUnusedPorts`](https://package.elm-lang.org/packages/sparksp/elm-review-ports/latest/NoUnusedPorts) - Ensure that all defined ports have been used.
 
 ## Example configuration
 
 ```elm
 import NoDuplicatePorts
+import NoUnsafePorts
 import NoUnusedPorts
 import Review.Rule exposing (Rule)
 
@@ -23,6 +25,7 @@ import Review.Rule exposing (Rule)
 config : List Rule
 config =
     [ NoDuplicatePorts.rule
+    , NoUnsafePorts.rule NoUnsafePorts.any
     , NoUnusedPorts.rule
     ]
 

--- a/elm.json
+++ b/elm.json
@@ -1,11 +1,12 @@
 {
     "type": "package",
     "name": "sparksp/elm-review-ports",
-    "summary": "Provides elm-review rules to detect errant elm ports.",
+    "summary": "Provides elm-review rules to detect problematic elm ports.",
     "license": "MIT",
     "version": "1.1.0",
     "exposed-modules": [
         "NoDuplicatePorts",
+        "NoUnsafePorts",
         "NoUnusedPorts"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "review-ports",
   "version": "1.1.0",
-  "description": "Review checks for your Elm ports",
+  "description": "Provides elm-review rules to detect problematic elm ports.",
   "repository": "https://github.com/github:sparksp/elm-review-ports",
   "author": "Phill Sparks <me@phills.me.uk>",
   "license": "MIT",

--- a/src/NoUnsafePorts.elm
+++ b/src/NoUnsafePorts.elm
@@ -48,6 +48,13 @@ If a port expecting an `Int` receives a `Float` it will cause a runtime error. W
 
     port alarm : String -> Cmd msg
 
+
+## Caveats
+
+  - Outgoing ports must accept a `Value` from `Json.Encode` or `Json.Decode` and result in a `Cmd`.
+  - Incoming ports must expect a `Value` from `Json.Encode` or `Json.Decode` and result in a `Sub`.
+  - The rule looks for the types `Cmd`, `Sub` and `Value` only - do not alias these types.
+
 -}
 rule : Rule
 rule =

--- a/src/NoUnsafePorts.elm
+++ b/src/NoUnsafePorts.elm
@@ -38,9 +38,10 @@ This rule reports any ports that do not send/receive a [`Json.Encode.Value`][Jso
 
 ## Why is this a problem?
 
-If a port expecting an `Int` receives a `Float` it will cause a runtime error. We can prevent this by just wrapping the incoming data as `Json.Encode.Value` and handling the data through a [`Decoder`][Json.Decode] instead. This guarantees that your application provides some sort of error handling.
+If a port expecting an `Int` receives a `Float` it will cause a runtime error. We can prevent this by just wrapping the incoming data as `Json.Encode.Value` and handling the data through a [`Decoder`][Json.Decode] instead. This guarantees that your application provides some sort of error handling. This is discussed in the Elm guide under [Verifying Flags].
 
 [Json.Decode]: https://package.elm-lang.org/packages/elm/json/latest/Json-Decode
+[Verifying Flags]: https://guide.elm-lang.org/interop/flags.html#verifying-flags
 
 
 ## Success

--- a/src/NoUnsafePorts.elm
+++ b/src/NoUnsafePorts.elm
@@ -1,0 +1,113 @@
+module NoUnsafePorts exposing (rule)
+
+{-|
+
+@docs rule
+
+-}
+
+import Elm.Syntax.Declaration as Declaration exposing (Declaration)
+import Elm.Syntax.Import as Import exposing (Import)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Range exposing (Range)
+import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
+import Review.Rule as Rule exposing (Error, Rule)
+
+
+{-| Forbid unsafe types in ports.
+
+    config : List Rule
+    config =
+        [ NoUnsafePorts.rule
+        ]
+
+This rule reports any ports that do not send/receive a `Json.Value`.
+
+
+## Why is this a problem?
+
+If a port expecting an `Int` receives a `Float` it will cause a runtime error. We can prevent this by just wrapping the incoming data as `Json.Encode.Value` and handling the data through a `Decoder` instead. This guarantees that your application provides some sort of error handling.
+
+
+## Success
+
+    port action : (Json.Decode.Value -> msg) -> Sub msg
+
+    port alarm : Json.Encode.Value -> Cmd msg
+
+
+## Failure
+
+    port action : (Int -> msg) -> Sub msg
+
+    port alarm : String -> Cmd msg
+
+-}
+rule : Rule
+rule =
+    Rule.newModuleRuleSchema "NoUnsafePorts" ()
+        |> Rule.withSimpleDeclarationVisitor declarationVisitor
+        |> Rule.fromModuleRuleSchema
+
+
+declarationVisitor : Node Declaration -> List (Error {})
+declarationVisitor node =
+    case Node.value node of
+        Declaration.PortDeclaration { name, typeAnnotation } ->
+            case Node.value typeAnnotation of
+                TypeAnnotation.FunctionTypeAnnotation portArguments portReturnType ->
+                    case Node.value portReturnType of
+                        TypeAnnotation.Typed (Node _ ( [], "Sub" )) _ ->
+                            case Node.value portArguments of
+                                TypeAnnotation.FunctionTypeAnnotation subMessageType _ ->
+                                    case Node.value subMessageType of
+                                        TypeAnnotation.Typed (Node _ ( [ "Json", "Decode" ], "Value" )) _ ->
+                                            []
+
+                                        TypeAnnotation.Typed (Node _ ( [ "Json", "Encode" ], "Value" )) _ ->
+                                            []
+
+                                        TypeAnnotation.Typed portType _ ->
+                                            [ unsafePortError (Node.value name) (portType |> Node.value |> formatType) (Node.range subMessageType) ]
+
+                                        TypeAnnotation.Record _ ->
+                                            [ unsafePortError (Node.value name) "record" (Node.range subMessageType) ]
+
+                                        TypeAnnotation.Tupled _ ->
+                                            [ unsafePortError (Node.value name) "tuple" (Node.range subMessageType) ]
+
+                                        _ ->
+                                            [ unsafePortError (Node.value name) "type" (Node.range subMessageType) ]
+
+                                _ ->
+                                    []
+
+                        TypeAnnotation.Typed (Node _ ( [], "Cmd" )) _ ->
+                            []
+
+                        _ ->
+                            []
+
+                _ ->
+                    []
+
+        _ ->
+            []
+
+
+unsafePortError : String -> String -> Range -> Error {}
+unsafePortError name portType range =
+    Rule.error
+        { message = "Port `" ++ name ++ "` expects unsafe " ++ portType ++ " data."
+        , details =
+            [ "When a port expecting an unsafe type receives data of another type it will cause a runtime error."
+            , "You should change this port to use `Json.Decode.Value` and use a `Decoder` result to handle any mismatched type errors."
+            ]
+        }
+        range
+
+
+formatType : ( ModuleName, String ) -> String
+formatType ( moduleName, name ) =
+    String.join "." (moduleName ++ [ name ])

--- a/src/NoUnsafePorts.elm
+++ b/src/NoUnsafePorts.elm
@@ -6,11 +6,12 @@ module NoUnsafePorts exposing (rule)
 
 -}
 
+import Dict exposing (Dict)
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
-import Elm.Syntax.Import as Import exposing (Import)
+import Elm.Syntax.Exposing as Exposing exposing (Exposing)
+import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.ModuleName exposing (ModuleName)
-import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Range exposing (Range)
+import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
 import Review.Rule as Rule exposing (Error, Rule)
 
@@ -22,12 +23,16 @@ import Review.Rule as Rule exposing (Error, Rule)
         [ NoUnsafePorts.rule
         ]
 
-This rule reports any ports that do not send/receive a `Json.Value`.
+This rule reports any ports that do not send/receive a [`Json.Encode.Value`][Json.Encode.Value].
+
+[Json.Encode.Value]: https://package.elm-lang.org/packages/elm/json/latest/Json-Encode#Value
 
 
 ## Why is this a problem?
 
-If a port expecting an `Int` receives a `Float` it will cause a runtime error. We can prevent this by just wrapping the incoming data as `Json.Encode.Value` and handling the data through a `Decoder` instead. This guarantees that your application provides some sort of error handling.
+If a port expecting an `Int` receives a `Float` it will cause a runtime error. We can prevent this by just wrapping the incoming data as `Json.Encode.Value` and handling the data through a [`Decoder`][Json.Decode] instead. This guarantees that your application provides some sort of error handling.
+
+[Json.Decode]: https://package.elm-lang.org/packages/elm/json/latest/Json-Decode
 
 
 ## Success
@@ -46,48 +51,29 @@ If a port expecting an `Int` receives a `Float` it will cause a runtime error. W
 -}
 rule : Rule
 rule =
-    Rule.newModuleRuleSchema "NoUnsafePorts" ()
-        |> Rule.withSimpleDeclarationVisitor declarationVisitor
+    Rule.newModuleRuleSchema "NoUnsafePorts" initialModuleContext
+        |> Rule.withImportVisitor importVisitor
+        |> Rule.withDeclarationListVisitor declarationListVisitor
         |> Rule.fromModuleRuleSchema
 
 
-declarationVisitor : Node Declaration -> List (Error {})
-declarationVisitor node =
+importVisitor : Node Import -> ModuleContext -> ( List (Error {}), ModuleContext )
+importVisitor node context =
+    ( [], rememberImportedModule (Node.value node) context )
+
+
+declarationListVisitor : List (Node Declaration) -> ModuleContext -> ( List (Error {}), ModuleContext )
+declarationListVisitor nodes context =
+    ( List.concatMap (checkDeclaration context) nodes, context )
+
+
+checkDeclaration : ModuleContext -> Node Declaration -> List (Error {})
+checkDeclaration context node =
     case Node.value node of
         Declaration.PortDeclaration { name, typeAnnotation } ->
             case Node.value typeAnnotation of
                 TypeAnnotation.FunctionTypeAnnotation portArguments portReturnType ->
-                    case Node.value portReturnType of
-                        TypeAnnotation.Typed (Node _ ( [], "Sub" )) _ ->
-                            case Node.value portArguments of
-                                TypeAnnotation.FunctionTypeAnnotation subMessageType _ ->
-                                    case Node.value subMessageType of
-                                        TypeAnnotation.Typed (Node _ ( [ "Json", "Decode" ], "Value" )) _ ->
-                                            []
-
-                                        TypeAnnotation.Typed (Node _ ( [ "Json", "Encode" ], "Value" )) _ ->
-                                            []
-
-                                        TypeAnnotation.Typed portType _ ->
-                                            [ unsafePortError (Node.value name) (portType |> Node.value |> formatType) (Node.range subMessageType) ]
-
-                                        TypeAnnotation.Record _ ->
-                                            [ unsafePortError (Node.value name) "record" (Node.range subMessageType) ]
-
-                                        TypeAnnotation.Tupled _ ->
-                                            [ unsafePortError (Node.value name) "tuple" (Node.range subMessageType) ]
-
-                                        _ ->
-                                            [ unsafePortError (Node.value name) "type" (Node.range subMessageType) ]
-
-                                _ ->
-                                    []
-
-                        TypeAnnotation.Typed (Node _ ( [], "Cmd" )) _ ->
-                            []
-
-                        _ ->
-                            []
+                    checkPort context (Node.value name) portArguments (getPortType portReturnType)
 
                 _ ->
                     []
@@ -96,18 +82,206 @@ declarationVisitor node =
             []
 
 
-unsafePortError : String -> String -> Range -> Error {}
-unsafePortError name portType range =
+checkPort : ModuleContext -> String -> Node TypeAnnotation -> Maybe PortType -> List (Error {})
+checkPort context name portArguments portReturnType =
+    case portReturnType of
+        Just IncomingPort ->
+            checkIncomingPort context name portArguments
+
+        Just OutgoingPort ->
+            []
+
+        Nothing ->
+            -- There is something off about this port declaration. The compiler will complain about this.
+            []
+
+
+checkIncomingPort : ModuleContext -> String -> Node TypeAnnotation -> List (Error {})
+checkIncomingPort context name portArguments =
+    case Node.value portArguments of
+        TypeAnnotation.FunctionTypeAnnotation subMessageType _ ->
+            case Node.value subMessageType of
+                TypeAnnotation.Typed portType _ ->
+                    case expandFunctionCall context (Node.value portType) of
+                        ( [ "Json", "Decode" ], "Value" ) ->
+                            []
+
+                        ( [ "Json", "Encode" ], "Value" ) ->
+                            []
+
+                        expandedPortType ->
+                            [ unsafePortError name (Node.map (\_ -> formatType expandedPortType) subMessageType) ]
+
+                TypeAnnotation.Record _ ->
+                    [ unsafePortError name (Node.map (\_ -> "record") subMessageType) ]
+
+                TypeAnnotation.Tupled _ ->
+                    [ unsafePortError name (Node.map (\_ -> "tuple") subMessageType) ]
+
+                _ ->
+                    [ unsafePortError name (Node.map (\_ -> "type") subMessageType) ]
+
+        _ ->
+            -- There is something off about this port declaration. The compiler will complain about this
+            []
+
+
+getPortType : Node TypeAnnotation -> Maybe PortType
+getPortType portReturnType =
+    case Node.value portReturnType of
+        TypeAnnotation.Typed node _ ->
+            case Node.value node of
+                ( [], "Sub" ) ->
+                    Just IncomingPort
+
+                ( [], "Cmd" ) ->
+                    Just OutgoingPort
+
+                _ ->
+                    Nothing
+
+        _ ->
+            Nothing
+
+
+type PortType
+    = IncomingPort
+    | OutgoingPort
+
+
+type ModuleContext
+    = Context
+        { aliases : Dict ModuleName ModuleName
+        , imports : Dict String ModuleName
+        }
+
+
+initialModuleContext : ModuleContext
+initialModuleContext =
+    Context
+        { aliases = Dict.empty
+        , imports = Dict.empty
+        }
+
+
+rememberImportedModule : Import -> ModuleContext -> ModuleContext
+rememberImportedModule { moduleName, moduleAlias, exposingList } context =
+    let
+        moduleNameValue : ModuleName
+        moduleNameValue =
+            Node.value moduleName
+    in
+    case moduleNameValue of
+        "Json" :: _ ->
+            context
+                |> rememberImportedAlias moduleNameValue moduleAlias
+                |> rememberImportedList moduleNameValue exposingList
+
+        _ ->
+            context
+
+
+rememberImportedAlias : ModuleName -> Maybe (Node ModuleName) -> ModuleContext -> ModuleContext
+rememberImportedAlias moduleName maybeModuleAlias (Context context) =
+    case Maybe.map Node.value maybeModuleAlias of
+        Just moduleAlias ->
+            Context { context | aliases = Dict.insert moduleAlias moduleName context.aliases }
+
+        Nothing ->
+            Context context
+
+
+rememberImportedList : ModuleName -> Maybe (Node Exposing) -> ModuleContext -> ModuleContext
+rememberImportedList moduleName exposingList context =
+    case Maybe.map Node.value exposingList of
+        Just (Exposing.All _) ->
+            rememberImportedAllModule moduleName context
+
+        Just (Exposing.Explicit list) ->
+            rememberImportedExplicitList moduleName list context
+
+        Nothing ->
+            context
+
+
+rememberImportedAllModule : ModuleName -> ModuleContext -> ModuleContext
+rememberImportedAllModule moduleName context =
+    case moduleName of
+        [ "Json", "Decode" ] ->
+            rememberImport ( moduleName, "Value" ) context
+
+        [ "Json", "Encode" ] ->
+            rememberImport ( moduleName, "Value" ) context
+
+        _ ->
+            context
+
+
+rememberImportedExplicitList : ModuleName -> List (Node Exposing.TopLevelExpose) -> ModuleContext -> ModuleContext
+rememberImportedExplicitList moduleName list context =
+    List.foldl (rememberImportedItem moduleName) context list
+
+
+rememberImportedItem : ModuleName -> Node Exposing.TopLevelExpose -> ModuleContext -> ModuleContext
+rememberImportedItem moduleName item context =
+    case Node.value item of
+        Exposing.FunctionExpose _ ->
+            context
+
+        Exposing.InfixExpose _ ->
+            context
+
+        Exposing.TypeOrAliasExpose name ->
+            rememberImport ( moduleName, name ) context
+
+        Exposing.TypeExpose { name } ->
+            rememberImport ( moduleName, name ) context
+
+
+rememberImport : ( ModuleName, String ) -> ModuleContext -> ModuleContext
+rememberImport ( moduleName, name ) (Context context) =
+    Context { context | imports = Dict.insert name moduleName context.imports }
+
+
+expandFunctionCall : ModuleContext -> ( ModuleName, String ) -> ( ModuleName, String )
+expandFunctionCall (Context { aliases, imports }) ( moduleCall, functionCall ) =
+    let
+        expandedModule : ModuleName
+        expandedModule =
+            case moduleCall of
+                [] ->
+                    lookupFunctionModule imports functionCall
+
+                _ ->
+                    lookupModuleAlias aliases moduleCall
+    in
+    ( expandedModule, functionCall )
+
+
+lookupFunctionModule : Dict String ModuleName -> String -> ModuleName
+lookupFunctionModule imports function =
+    Dict.get function imports
+        |> Maybe.withDefault []
+
+
+lookupModuleAlias : Dict ModuleName ModuleName -> ModuleName -> ModuleName
+lookupModuleAlias aliases moduleName =
+    Dict.get moduleName aliases
+        |> Maybe.withDefault moduleName
+
+
+unsafePortError : String -> Node String -> Error {}
+unsafePortError name portType =
     Rule.error
-        { message = "Port `" ++ name ++ "` expects unsafe " ++ portType ++ " data."
+        { message = "Port `" ++ name ++ "` expects unsafe " ++ Node.value portType ++ " data."
         , details =
             [ "When a port expecting an unsafe type receives data of another type it will cause a runtime error."
             , "You should change this port to use `Json.Decode.Value` and use a `Decoder` result to handle any mismatched type errors."
             ]
         }
-        range
+        (Node.range portType)
 
 
 formatType : ( ModuleName, String ) -> String
 formatType ( moduleName, name ) =
-    String.join "." (moduleName ++ [ name ])
+    "`" ++ String.join "." (moduleName ++ [ name ]) ++ "`"

--- a/tests/NoUnsafePortsTests.elm
+++ b/tests/NoUnsafePortsTests.elm
@@ -156,8 +156,8 @@ main = 1"""
             \_ ->
                 """
 module Main exposing (main)
-import Json.Encode as E
-port action : (E.Value -> msg) -> Sub msg
+import Json.Encode as Encode
+port action : (Encode.Value -> msg) -> Sub msg
 main = 1"""
                     |> Review.Test.run (rule NoUnsafePorts.any)
                     |> Review.Test.expectNoErrors
@@ -276,8 +276,8 @@ main = 1"""
             \_ ->
                 """
 module Main exposing (main)
-import Json.Encode as E
-port action : E.Value -> Cmd msg
+import Json.Encode as Encode
+port action : Encode.Value -> Cmd msg
 main = 1"""
                     |> Review.Test.run (rule NoUnsafePorts.any)
                     |> Review.Test.expectNoErrors

--- a/tests/NoUnsafePortsTests.elm
+++ b/tests/NoUnsafePortsTests.elm
@@ -1,0 +1,150 @@
+module NoUnsafePortsTests exposing (all)
+
+import Fuzz exposing (Fuzzer)
+import NoUnsafePorts exposing (rule)
+import Review.Test
+import Test exposing (Test, describe, fuzz, test)
+
+
+incomingPortTests : Test
+incomingPortTests =
+    describe "incoming ports"
+        [ fuzz fuzzUnsafeType "unsafe type" <|
+            \unsafeType ->
+                portModule unsafeType
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ unsafePortError { name = "action", type_ = unsafeType, under = unsafeType }
+                        ]
+        , fuzz fuzzMaybeType "maybe type" <|
+            \maybeType ->
+                portModule maybeType
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ unsafePortError { name = "action", type_ = "Maybe", under = maybeType }
+                        ]
+        , fuzz fuzzListType "list type" <|
+            \listType ->
+                portModule listType
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ unsafePortError { name = "action", type_ = "List", under = listType }
+                        ]
+        , fuzz fuzzArrayType "array type" <|
+            \arrayType ->
+                portModule arrayType
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ unsafePortError { name = "action", type_ = "Array", under = arrayType }
+                        ]
+        , test "record type" <|
+            \_ ->
+                portModule "{ message : String }"
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ unsafePortError { name = "action", type_ = "record", under = "{ message : String }" }
+                        ]
+        , test "tuple type" <|
+            \_ ->
+                portModule "( String, Int )"
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ unsafePortError { name = "action", type_ = "tuple", under = "( String, Int )" }
+                        ]
+        , test "Json.Decode.Value type" <|
+            \_ ->
+                """
+module Main exposing (main)
+import Json.Decode
+port action : (Json.Decode.Value -> msg) -> Sub msg
+main = 1"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
+        , test "Json.Encode.Value type" <|
+            \_ ->
+                """
+module Main exposing (main)
+import Json.Encode
+port action : (Json.Encode.Value -> msg) -> Sub msg
+main = 1"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
+        , Test.todo "exposed Json.Decode.Value type"
+        , Test.todo "exposed Json.Encode.Value type"
+        , Test.todo "aliased Json.Decode.Value type"
+        , Test.todo "aliased Json.Encode.Value type"
+        ]
+
+
+fuzzUnsafeType : Fuzzer String
+fuzzUnsafeType =
+    Fuzz.oneOf
+        [ Fuzz.constant "Bool"
+        , Fuzz.constant "Int"
+        , Fuzz.constant "Float"
+        , Fuzz.constant "String"
+        ]
+
+
+fuzzMaybeType : Fuzzer String
+fuzzMaybeType =
+    Fuzz.oneOf
+        [ Fuzz.constant "Maybe Bool"
+        , Fuzz.constant "Maybe Int"
+        , Fuzz.constant "Maybe Float"
+        , Fuzz.constant "Maybe String"
+        ]
+
+
+fuzzListType : Fuzzer String
+fuzzListType =
+    Fuzz.oneOf
+        [ Fuzz.constant "List Bool"
+        , Fuzz.constant "List Int"
+        , Fuzz.constant "List Float"
+        , Fuzz.constant "List String"
+        ]
+
+
+fuzzArrayType : Fuzzer String
+fuzzArrayType =
+    Fuzz.oneOf
+        [ Fuzz.constant "Array Bool"
+        , Fuzz.constant "Array Int"
+        , Fuzz.constant "Array Float"
+        , Fuzz.constant "Array String"
+        ]
+
+
+outgoingPortTests : Test
+outgoingPortTests =
+    Test.todo "outgoing ports"
+
+
+all : Test
+all =
+    describe "NoUnsafePorts"
+        [ incomingPortTests
+        , outgoingPortTests
+        ]
+
+
+unsafePortError : { name : String, type_ : String, under : String } -> Review.Test.ExpectedError
+unsafePortError { name, type_, under } =
+    Review.Test.error
+        { message = "Port `" ++ name ++ "` expects unsafe " ++ type_ ++ " data."
+        , details =
+            [ "When a port expecting an unsafe type receives data of another type it will cause a runtime error."
+            , "You should change this port to use `Json.Decode.Value` and use a `Decoder` result to handle any mismatched type errors."
+            ]
+        , under = under
+        }
+
+
+portModule : String -> String
+portModule portType =
+    String.join "\n"
+        [ "module Main exposing (main)"
+        , "port action : (" ++ portType ++ " -> msg) -> Sub msg"
+        , "main = 1"
+        ]

--- a/tests/NoUnsafePortsTests.elm
+++ b/tests/NoUnsafePortsTests.elm
@@ -329,16 +329,23 @@ unsafeIncomingPortError { name, type_, under } =
     Review.Test.error
         { message = "Port `" ++ name ++ "` expects unsafe " ++ type_ ++ " data."
         , details =
-            [ "When a port expecting an unsafe type receives data of another type it will cause a runtime error."
-            , "You should change this port to use `Json.Decode.Value` and use a `Decoder` result to handle any mismatched type errors."
+            [ "When a port expecting a basic type receives data of another type it will cause a runtime error."
+            , "You should change this port to use `Json.Encode.Value` and write a `Decoder` handle the data."
             ]
         , under = under
         }
 
 
 unsafeOutgoingPortError : { name : String, type_ : String, under : String } -> Review.Test.ExpectedError
-unsafeOutgoingPortError =
-    unsafeIncomingPortError
+unsafeOutgoingPortError { name, type_, under } =
+    Review.Test.error
+        { message = "Port `" ++ name ++ "` sends unsafe " ++ type_ ++ " data."
+        , details =
+            [ "When a port expecting an unsafe type receives data of another type it will cause a runtime error."
+            , "You should change this port to use `Json.Encode.Value` and use an `Encoder` to generate a safe value."
+            ]
+        , under = under
+        }
 
 
 incomingPortModule : String -> String


### PR DESCRIPTION
# NoUnsafePorts

Forbid unsafe types in ports.

```elm
config : List Rule
config =
    [ NoUnsafePorts.rule NoUnsafePorts.any
    ]
```

This rule reports any ports that do not send/receive a [`Json.Encode.Value`][Json.Encode.Value].

[Json.Encode.Value]: https://package.elm-lang.org/packages/elm/json/latest/Json-Encode#Value

## Why is this a problem?

If a port expecting an `Int` receives a `Float` it will cause a runtime error. We can prevent this by just wrapping the incoming data as `Json.Encode.Value` and handling the data through a [`Decoder`][Json.Decode] instead. This guarantees that your application provides some sort of error handling.  This is discussed in the Elm guide under [Verifying Flags].

[Json.Decode]: https://package.elm-lang.org/packages/elm/json/latest/Json-Decode
[Verifying Flags]: https://guide.elm-lang.org/interop/flags.html#verifying-flags

## Success

```elm
port action : (Json.Decode.Value -> msg) -> Sub msg

port alarm : Json.Encode.Value -> Cmd msg
```


## Failure

```elm
port action : (Int -> msg) -> Sub msg

port alarm : String -> Cmd msg
```


## Caveats

  - Outgoing ports must accept a `Value` from `Json.Encode` or `Json.Decode` and result in a `Cmd`.
  - Incoming ports must expect a `Value` from `Json.Encode` or `Json.Decode` and result in a `Sub`.
  - The rule looks for the types `Cmd`, `Sub` and `Value` only - do not alias these types.

## Config

### onlyIncomingPorts

Check incoming ports only.

```elm
config : List Rule
config =
    [ NoUnsafePorts.rule NoUnsafePorts.onlyIncomingPorts
    ]
```

Use this option if you want to allow basic types in outgoing ports.


## Todo

- [x] Incoming Ports
- [x] Outgoing Ports
- [x] Handle aliased and exposed imports
- [x] Option: Only check incoming ports
- [x] Documentation
- [x] Update `README.md` and `elm.json`