### PR TITLE
Use best practice ports in examples

### DIFF
--- a/tests/NoDuplicatePortsTests.elm
+++ b/tests/NoDuplicatePortsTests.elm
@@ -27,8 +27,9 @@ a = 1"""
             \_ ->
                 """
 port module A exposing (a)
-port send : String -> Cmd msg
-port recv : (String -> msg) -> Sub msg
+import Json.Encode as E
+port send : E.Value -> Cmd msg
+port recv : (E.Value -> msg) -> Sub msg
 a = 1"""
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
@@ -36,12 +37,14 @@ a = 1"""
             \_ ->
                 [ """
 port module A exposing (a)
-port send : String -> Cmd msg
-port recv : (String -> msg) -> Sub msg
+import Json.Encode as E
+port send : E.Value -> Cmd msg
+port recv : (E.Value -> msg) -> Sub msg
 a = 1""", """
 port module B exposing (b)
-port send : String -> Cmd msg
-port recv : (String -> msg) -> Sub msg
+import Json.Encode as E
+port send : E.Value -> Cmd msg
+port recv : (E.Value -> msg) -> Sub msg
 b = 1""" ]
                     |> Review.Test.runOnModules rule
                     |> Review.Test.expectErrorsForModules


### PR DESCRIPTION
It is best practice to only use `Json.Encode.Value` in ports, so I've updated the examples to reflect this.