### PR TITLE
Stop using deprecated visitors

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,8 +12,8 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "jfmengels/elm-review": "2.0.0 <= v < 3.0.0",
-        "stil4m/elm-syntax": "7.1.1 <= v < 8.0.0"
+        "jfmengels/elm-review": "2.2.0 <= v < 3.0.0",
+        "stil4m/elm-syntax": "7.1.3 <= v < 8.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.2 <= v < 2.0.0"

--- a/src/NoDuplicatePorts.elm
+++ b/src/NoDuplicatePorts.elm
@@ -11,7 +11,7 @@ import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Range exposing (Range)
-import Review.Rule as Rule exposing (Error, Rule)
+import Review.Rule as Rule exposing (Rule)
 
 
 {-| Forbid duplicate port names in your project.
@@ -114,14 +114,14 @@ mergePortLocationDicts portName newLocations oldLocations =
     Dict.insert portName (Dict.union newLocations oldLocations)
 
 
-finalProjectEvaluation : ProjectContext -> List (Error scope)
+finalProjectEvaluation : ProjectContext -> List (Rule.Error scope)
 finalProjectEvaluation projectContext =
     projectContext
         |> Dict.toList
         |> fastConcatMap errorsFromPortLocations
 
 
-errorsFromPortLocations : ( String, Dict ModuleName PortLocation ) -> List (Error scope)
+errorsFromPortLocations : ( String, Dict ModuleName PortLocation ) -> List (Rule.Error scope)
 errorsFromPortLocations ( portName, locations ) =
     if Dict.size locations < 2 then
         []
@@ -132,7 +132,7 @@ errorsFromPortLocations ( portName, locations ) =
             |> List.map (errorFromPortLocation portName)
 
 
-errorFromPortLocation : String -> ( Rule.ModuleKey, Range ) -> Error scope
+errorFromPortLocation : String -> ( Rule.ModuleKey, Range ) -> Rule.Error scope
 errorFromPortLocation portName ( moduleKey, range ) =
     Rule.errorForModule moduleKey (error portName) range
 

--- a/src/NoDuplicatePorts.elm
+++ b/src/NoDuplicatePorts.elm
@@ -118,7 +118,7 @@ finalProjectEvaluation : ProjectContext -> List (Error scope)
 finalProjectEvaluation projectContext =
     projectContext
         |> Dict.toList
-        |> List.concatMap errorsFromPortLocations
+        |> fastConcatMap errorsFromPortLocations
 
 
 errorsFromPortLocations : ( String, Dict ModuleName PortLocation ) -> List (Error scope)
@@ -142,3 +142,12 @@ error portName =
     { message = String.concat [ "Another port named `", portName, "` already exists." ]
     , details = [ "When there are multiple ports with the same name you may encounter a JavaScript runtime error." ]
     }
+
+
+
+--- FASTER LIST OPERATIONS
+
+
+fastConcatMap : (a -> List b) -> List a -> List b
+fastConcatMap fn list =
+    List.foldr (fn >> (++)) [] list

--- a/src/NoUnsafePorts.elm
+++ b/src/NoUnsafePorts.elm
@@ -114,7 +114,7 @@ importVisitor node context =
 
 declarationListVisitor : List (Node Declaration) -> ModuleContext -> ( List (Error {}), ModuleContext )
 declarationListVisitor nodes context =
-    ( List.concatMap (checkDeclaration context) nodes, context )
+    ( fastConcatMap (checkDeclaration context) nodes, context )
 
 
 checkDeclaration : ModuleContext -> Node Declaration -> List (Error {})
@@ -378,3 +378,12 @@ unsafeOutgoingPortError name portType =
 formatType : ( ModuleName, String ) -> String
 formatType ( moduleName, name ) =
     "`" ++ String.join "." (moduleName ++ [ name ]) ++ "`"
+
+
+
+--- FASTER LIST OPERATIONS
+
+
+fastConcatMap : (a -> List b) -> List a -> List b
+fastConcatMap fn list =
+    List.foldr (fn >> (++)) [] list

--- a/src/NoUnsafePorts.elm
+++ b/src/NoUnsafePorts.elm
@@ -21,7 +21,7 @@ import Elm.Syntax.Import exposing (Import)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation)
-import Review.Rule as Rule exposing (Error, Rule)
+import Review.Rule as Rule exposing (Rule)
 
 
 {-| Forbid unsafe types in ports.
@@ -107,17 +107,17 @@ onlyIncomingPorts =
 --- VISITORS
 
 
-importVisitor : Node Import -> ModuleContext -> ( List (Error {}), ModuleContext )
+importVisitor : Node Import -> ModuleContext -> ( List nothing, ModuleContext )
 importVisitor node context =
     ( [], rememberImportedModule (Node.value node) context )
 
 
-declarationListVisitor : List (Node Declaration) -> ModuleContext -> ( List (Error {}), ModuleContext )
+declarationListVisitor : List (Node Declaration) -> ModuleContext -> ( List (Rule.Error {}), ModuleContext )
 declarationListVisitor nodes context =
     ( fastConcatMap (checkDeclaration context) nodes, context )
 
 
-checkDeclaration : ModuleContext -> Node Declaration -> List (Error {})
+checkDeclaration : ModuleContext -> Node Declaration -> List (Rule.Error {})
 checkDeclaration context node =
     case Node.value node of
         Declaration.PortDeclaration { name, typeAnnotation } ->
@@ -132,7 +132,7 @@ checkDeclaration context node =
             []
 
 
-checkPort : ModuleContext -> String -> Node TypeAnnotation -> Maybe PortType -> List (Error {})
+checkPort : ModuleContext -> String -> Node TypeAnnotation -> Maybe PortType -> List (Rule.Error {})
 checkPort ((Context { check }) as context) name portArguments maybePortType =
     case Maybe.map (\portType -> ( portType, canCheck check portType )) maybePortType of
         Just ( IncomingPort, True ) ->
@@ -150,7 +150,7 @@ checkPort ((Context { check }) as context) name portArguments maybePortType =
             []
 
 
-checkIncomingPort : ModuleContext -> String -> Node TypeAnnotation -> List (Error {})
+checkIncomingPort : ModuleContext -> String -> Node TypeAnnotation -> List (Rule.Error {})
 checkIncomingPort context name portArguments =
     case Node.value portArguments of
         TypeAnnotation.FunctionTypeAnnotation subMessageType _ ->
@@ -161,12 +161,12 @@ checkIncomingPort context name portArguments =
             []
 
 
-checkOutgoingPort : ModuleContext -> String -> Node TypeAnnotation -> List (Error {})
+checkOutgoingPort : ModuleContext -> String -> Node TypeAnnotation -> List (Rule.Error {})
 checkOutgoingPort context name portArguments =
     checkPortArguments context (unsafeOutgoingPortError name) portArguments
 
 
-checkPortArguments : ModuleContext -> (Node String -> Error {}) -> Node TypeAnnotation -> List (Error {})
+checkPortArguments : ModuleContext -> (Node String -> Rule.Error {}) -> Node TypeAnnotation -> List (Rule.Error {})
 checkPortArguments context makeError portArguments =
     case Node.value portArguments of
         TypeAnnotation.Typed portType _ ->
@@ -351,7 +351,7 @@ lookupModuleAlias aliases moduleName =
         |> Maybe.withDefault moduleName
 
 
-unsafeIncomingPortError : String -> Node String -> Error {}
+unsafeIncomingPortError : String -> Node String -> Rule.Error {}
 unsafeIncomingPortError name portType =
     Rule.error
         { message = "Port `" ++ name ++ "` expects unsafe " ++ Node.value portType ++ " data."
@@ -363,7 +363,7 @@ unsafeIncomingPortError name portType =
         (Node.range portType)
 
 
-unsafeOutgoingPortError : String -> Node String -> Error {}
+unsafeOutgoingPortError : String -> Node String -> Rule.Error {}
 unsafeOutgoingPortError name portType =
     Rule.error
         { message = "Port `" ++ name ++ "` sends unsafe " ++ Node.value portType ++ " data."

--- a/src/NoUnusedPorts.elm
+++ b/src/NoUnusedPorts.elm
@@ -15,7 +15,7 @@ import Elm.Syntax.Module as Module exposing (Module)
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Range exposing (Range)
-import Review.Rule as Rule exposing (Error, Rule)
+import Review.Rule as Rule exposing (Rule)
 import Set exposing (Set)
 
 
@@ -172,7 +172,7 @@ expressionVisitor node context =
             ( [], context )
 
 
-finalEvaluation : ProjectContext -> List (Error scope)
+finalEvaluation : ProjectContext -> List (Rule.Error scope)
 finalEvaluation { functionCalls, ports } =
     ports |> Dict.toList |> List.map (reportUnusedPort functionCalls)
 
@@ -181,7 +181,7 @@ finalEvaluation { functionCalls, ports } =
 --- REPORT
 
 
-reportUnusedPort : FunctionCalls -> ( ( ModuleName, String ), Port ) -> Error scope
+reportUnusedPort : FunctionCalls -> ( ( ModuleName, String ), Port ) -> Rule.Error scope
 reportUnusedPort functionCalls ( ( moduleName, portName ), Port { range, moduleKey } ) =
     let
         callers : Maybe (Set ( ModuleName, String ))

--- a/src/NoUnusedPorts.elm
+++ b/src/NoUnusedPorts.elm
@@ -93,8 +93,8 @@ moduleVisitor schema =
         |> Rule.withModuleDefinitionVisitor moduleDefinitionVisitor
         |> Rule.withImportVisitor (guardedDeclarationVisitor importVisitor)
         |> Rule.withDeclarationListVisitor (guardedDeclarationVisitor declarationListVisitor)
-        |> Rule.withDeclarationVisitor (guardedExpressionVisitor declarationVisitor)
-        |> Rule.withExpressionVisitor (guardedExpressionVisitor expressionVisitor)
+        |> Rule.withDeclarationEnterVisitor (guardedExpressionVisitor declarationVisitor)
+        |> Rule.withExpressionEnterVisitor (guardedExpressionVisitor expressionVisitor)
 
 
 {-| Only visit imports and declaration lists if are a port module or know about any ports.
@@ -103,7 +103,7 @@ moduleVisitor schema =
   - We may declare our own ports.
 
 -}
-guardedDeclarationVisitor : (a -> ModuleContext -> ( List (Error {}), ModuleContext )) -> a -> ModuleContext -> ( List (Error {}), ModuleContext )
+guardedDeclarationVisitor : (a -> ModuleContext -> ( List error, ModuleContext )) -> a -> ModuleContext -> ( List error, ModuleContext )
 guardedDeclarationVisitor visitor a context =
     if context.isPortModule || context.hasPorts then
         visitor a context
@@ -118,16 +118,16 @@ guardedDeclarationVisitor visitor a context =
   - We may have declared our own ports.
 
 -}
-guardedExpressionVisitor : (a -> b -> ModuleContext -> ( List (Error {}), ModuleContext )) -> a -> b -> ModuleContext -> ( List (Error {}), ModuleContext )
-guardedExpressionVisitor visitor a b context =
+guardedExpressionVisitor : (Node a -> ModuleContext -> ( List error, ModuleContext )) -> Node a -> ModuleContext -> ( List error, ModuleContext )
+guardedExpressionVisitor visitor a context =
     if context.hasPorts then
-        visitor a b context
+        visitor a context
 
     else
         ( [], context )
 
 
-moduleDefinitionVisitor : Node Module -> ModuleContext -> ( List (Error {}), ModuleContext )
+moduleDefinitionVisitor : Node Module -> ModuleContext -> ( List nothing, ModuleContext )
 moduleDefinitionVisitor node context =
     case Node.value node of
         Module.PortModule _ ->
@@ -137,20 +137,20 @@ moduleDefinitionVisitor node context =
             ( [], { context | isPortModule = False } )
 
 
-importVisitor : Node Import -> ModuleContext -> ( List (Error {}), ModuleContext )
+importVisitor : Node Import -> ModuleContext -> ( List nothing, ModuleContext )
 importVisitor node context =
     ( [], rememberImportedModule (Node.value node) context )
 
 
-declarationListVisitor : List (Node Declaration) -> ModuleContext -> ( List (Error {}), ModuleContext )
+declarationListVisitor : List (Node Declaration) -> ModuleContext -> ( List nothing, ModuleContext )
 declarationListVisitor declarations context =
     ( [], List.foldl rememberDeclaration context declarations )
 
 
-declarationVisitor : Node Declaration -> Rule.Direction -> ModuleContext -> ( List (Error {}), ModuleContext )
-declarationVisitor node direction context =
-    case ( direction, Node.value node ) of
-        ( Rule.OnEnter, Declaration.FunctionDeclaration { declaration } ) ->
+declarationVisitor : Node Declaration -> ModuleContext -> ( List nothing, ModuleContext )
+declarationVisitor node context =
+    case Node.value node of
+        Declaration.FunctionDeclaration { declaration } ->
             let
                 name : String
                 name =
@@ -162,10 +162,10 @@ declarationVisitor node direction context =
             ( [], context )
 
 
-expressionVisitor : Node Expression -> Rule.Direction -> ModuleContext -> ( List (Error {}), ModuleContext )
-expressionVisitor node direction context =
-    case ( direction, Node.value node ) of
-        ( Rule.OnEnter, Expression.FunctionOrValue moduleName name ) ->
+expressionVisitor : Node Expression -> ModuleContext -> ( List nothing, ModuleContext )
+expressionVisitor node context =
+    case Node.value node of
+        Expression.FunctionOrValue moduleName name ->
             ( [], rememberFunctionCall ( moduleName, name ) context )
 
         _ ->


### PR DESCRIPTION
elm-review has deprecated `withDeclarationVisitor` and `withExpressionVisitor` in favour of directional visitors to save calling one visitor in both directions when you're only interested in one.

I've also implemented a few patterns from other projects:
 - Use `List nothing` when the visitor returns no errors
 - Don't expose `Error` from `Review.Rule` and qualify it instead
 - Use faster `concatMap`
 - Use `withDeclarationListVisitor` for gathering intel