### PR TITLE
Improve performance of fastConcatMap

### DIFF
--- a/src/NoDuplicatePorts.elm
+++ b/src/NoDuplicatePorts.elm
@@ -158,5 +158,10 @@ error portName =
 
 
 fastConcatMap : (a -> List b) -> List a -> List b
-fastConcatMap fn list =
-    List.foldr (fn >> (++)) [] list
+fastConcatMap fn =
+    let
+        helper : a -> List b -> List b
+        helper item acc =
+            fn item ++ acc
+    in
+    List.foldr helper []

--- a/src/NoUnsafePorts.elm
+++ b/src/NoUnsafePorts.elm
@@ -319,5 +319,10 @@ filterCoreType type_ =
 
 
 fastConcatMap : (a -> List b) -> List a -> List b
-fastConcatMap fn list =
-    List.foldr (fn >> (++)) [] list
+fastConcatMap fn =
+    let
+        helper : a -> List b -> List b
+        helper item acc =
+            fn item ++ acc
+    in
+    List.foldr helper []


### PR DESCRIPTION
jfmengels discovered that a function/lambda is better than using `>>`: <https://github.com/jfmengels/elm-benchmarks>