### PR TITLE
Use vX versions of GitHub actions

### DIFF
--- a/.github/workflows/autofixes.yaml
+++ b/.github/workflows/autofixes.yaml
@@ -44,7 +44,7 @@ jobs:
         run: npx --no-install elm-review --fix-all-without-prompt
         continue-on-error: true
 
-      - uses: peter-evans/create-pull-request@v4.0.1
+      - uses: peter-evans/create-pull-request@v4
         with:
           commit-message: 'Apply elm-review fixes'
           branch: fixes/${{ steps.extract_branch.outputs.branch }}
@@ -88,7 +88,7 @@ jobs:
       - name: Build elm docs
         run: npx --no-install elm make --docs docs.json
 
-      - uses: peter-evans/create-pull-request@v4.0.1
+      - uses: peter-evans/create-pull-request@v4
         with:
           commit-message: 'Update docs.json'
           branch: docs/${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/autofixes.yaml
+++ b/.github/workflows/autofixes.yaml
@@ -15,14 +15,14 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-node_modules
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.elm
           key: ${{ runner.os }}-elm--home-${{ hashFiles('**/elm.json') }}
@@ -64,14 +64,14 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-node_modules
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.elm
           key: ${{ runner.os }}-elm--home-${{ hashFiles('**/elm.json') }}

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Check that examples are up to date
         run: npx --no-install node elm-review-package-tests/check-examples-were-updated.js
 
-      - uses: peter-evans/create-pull-request@v4.0.1
+      - uses: peter-evans/create-pull-request@v4
         if: always()
         with:
           commit-message: 'Update examples'

--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -17,14 +17,14 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-node_modules
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.elm
           key: ${{ runner.os }}-elm--home-${{ hashFiles('**/elm.json') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,14 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-node_modules
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.elm
           key: ${{ runner.os }}-elm--home-${{ hashFiles('**/elm.json') }}
@@ -44,14 +44,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-node_modules
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.elm
           key: ${{ runner.os }}-elm--home-${{ hashFiles('**/elm.json') }}
@@ -77,14 +77,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-node_modules
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.elm
           key: ${{ runner.os }}-elm--home-${{ hashFiles('**/elm.json') }}
@@ -111,14 +111,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-node_modules
 
-      - uses: actions/cache@v3.0.1
+      - uses: actions/cache@v3
         with:
           path: ~/.elm
           key: ${{ runner.os }}-elm--home-${{ hashFiles('**/elm.json') }}


### PR DESCRIPTION
These projects all maintain `vX` as pointing to the current patch version, so we don't need to update all the time.